### PR TITLE
Use OPM-action to install poetry, instead of abatilo/actions-poetry s…

### DIFF
--- a/.github/workflows/python_scripts.yml
+++ b/.github/workflows/python_scripts.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
-        uses: abatilo/actions-poetry@v2
+        uses: OPM/actions-poetry@master
       - name: Install dependencies
         run: |
           cd python/sphinx_docs


### PR DESCRIPTION
…o we do not depend on a third-party resource