### PR TITLE
Fix CVE-2025-66418, CVE-2025-66471, CVE-2026-21441: Update urllib3 to 2.6.3

### DIFF
--- a/python/sphinx_docs/poetry.lock
+++ b/python/sphinx_docs/poetry.lock
@@ -929,21 +929,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "win32-setctime"


### PR DESCRIPTION
Addresses Dependabot security alerts [#11](https://github.com/OPM/opm-python-documentation/security/dependabot/11), [#12](https://github.com/OPM/opm-python-documentation/security/dependabot/12), and [#13](https://github.com/OPM/opm-python-documentation/security/dependabot/13). These vulnerabilities allowed decompression-bomb attacks through various vectors in urllib3's streaming API.