### PR TITLE
Bump GitPython to 3.1.47 to fix two security advisories

### DIFF
--- a/python/sphinx_docs/poetry.lock
+++ b/python/sphinx_docs/poetry.lock
@@ -287,22 +287,22 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.44"
+version = "3.1.47"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110"},
-    {file = "gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269"},
+    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
+    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
-test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "idna"


### PR DESCRIPTION
## Summary
Bumps GitPython from 3.1.44 to 3.1.47 in `python/sphinx_docs/poetry.lock` to address two high-severity Dependabot alerts:

- **[GHSA-rpm5-65cw-6hj4](https://github.com/OPM/opm-python-documentation/security/dependabot/18)** (CVSS 8.8, CWE-78) — command injection via underscore-form `upload_pack=` / `receive_pack=` kwargs that bypass the unsafe-option check in `Repo.clone_from()`, `Remote.fetch/pull/push()`.
- **[GHSA-x2qx-6953-8485](https://github.com/OPM/opm-python-documentation/security/dependabot/19)** (CVSS 8.1, CWE-88) — argument injection: `multi_options` is validated before `shlex.split`, letting a string like `"--branch main --config core.hooksPath=..."` slip past the check.

Both are first patched in 3.1.47, so a single bump closes both alerts. The existing `gitpython = "^3.1.44"` constraint in `pyproject.toml` already permits 3.1.47, so only the lockfile changes.

## Test plan
- [x] `poetry update gitpython` — lockfile updated to 3.1.47, no other entries changed
- [x] `poetry install` succeeds
- [x] `poetry run pytest` passes
- [x] `import git; git.__version__ == "3.1.47"` confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)