### PR TITLE
Bump GitPython to 3.1.50 to fix three security advisories

### DIFF
--- a/python/sphinx_docs/poetry.lock
+++ b/python/sphinx_docs/poetry.lock
@@ -287,14 +287,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
-    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
+    {file = "gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9"},
+    {file = "gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### Bump GitPython to 3.1.50 to fix three security advisories

Updates the `gitpython` entry in `python/sphinx_docs/poetry.lock` from `3.1.47` to `3.1.50` to resolve three high-severity Dependabot alerts. The `pyproject.toml` constraint (`^3.1.44`) already permits 3.1.50, so only the lockfile changed.

#### Vulnerabilities fixed

- **[GHSA-7545-fcxq-7j24](https://github.com/advisories/GHSA-7545-fcxq-7j24)** (CVE-2026-44243, alert #20) — **Path traversal** in reference APIs allows arbitrary file write/delete outside the repository via crafted ref names passed to `Reference.create`, `SymbolicReference.set_reference`, `rename`, and `delete`. Patched in 3.1.48.
- **[GHSA-v87r-6q3f-2j67](https://github.com/advisories/GHSA-v87r-6q3f-2j67)** (CVE-2026-44244, alert #21) — **Newline injection** in the `value` parameter of `config_writer().set_value()` enables RCE via an injected `core.hooksPath`. Patched in 3.1.49.
- **[GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w)** (alert #22) — **Newline injection bypass** through the `section` parameter of `set_value()`, which the 3.1.49 patch missed.
