### PR TITLE
Bump urllib3 to 2.7.0 to fix two security advisories

### DIFF
--- a/python/sphinx_docs/poetry.lock
+++ b/python/sphinx_docs/poetry.lock
@@ -929,14 +929,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/sphinx_docs/poetry.lock
+++ b/python/sphinx_docs/poetry.lock
@@ -287,14 +287,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
-    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
+    {file = "gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9"},
+    {file = "gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Builds on #23.

Updates the `urllib3` entry in `python/sphinx_docs/poetry.lock` from `2.6.3` to `2.7.0` to resolve two high-severity Dependabot alerts. `urllib3` is a transitive dependency, so only the lockfile changed. This project already requires Python `^3.10`, so the bump in urllib3's own Python-version requirement (`>=3.9` → `>=3.10`) is a no-op.

#### Vulnerabilities fixed

- **[GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j)** (CVE-2026-44432, alert #23) — **Decompression-bomb safeguards bypassed** in parts of the streaming API. Patched in 2.7.0.
- **[GHSA-qccp-gfcp-xxvc](https://github.com/advisories/GHSA-qccp-gfcp-xxvc)** (CVE-2026-44431, alert #24) — **Sensitive headers forwarded across origins** in proxied low-level redirects. Patched in 2.7.0.
